### PR TITLE
realtek-poe: Fix status for devices with more than 8 PoE ports

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 typedef int (*poe_reply_handler)(unsigned char *reply);
 
 #define MAX_PORT	24
-#define GET_STR(a, b)	(a < ARRAY_SIZE(b) ? b[a] : NULL)
+#define GET_STR(a, b)	((a) < ARRAY_SIZE(b) ? (b)[a] : NULL)
 
 struct port_config {
 	char name[16];


### PR DESCRIPTION
Only status data for the first 8 ports was requested. Most devices
have 8 ports, and the reply packet has room for 8 ports. It was the
perfect match!

People quickly figured out realtek-poe works for unicorn switches with
more than 8 PoE ports. And so they did. And they increased MAX_PORT
without regards to the out-of-bounds access problem they created. And
realtek-poe refused to crash!

Stop reading past the end of the packet in poe_reply_port_overview().
Just requests more packets if there are more than 8 ports.

Fixes: https://github.com/Hurricos/realtek-poe/commit/8c429f1d17e1e5b063043ee06a791fcb2bfcaf20 ("realtek-poe: Increment up to MAX_PORT, not 8")