### PR TITLE
realtek-poe: Add PSE ID quirk for Zyxel GS1900-24HP-v1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 typedef int (*poe_reply_handler)(unsigned char *reply);
 
 #define MAX_PORT	24
-#define GET_STR(a, b)	(a < ARRAY_SIZE(b) ? b[a] : NULL)
+#define GET_STR(a, b)	((a) < ARRAY_SIZE(b) ? (b)[a] : NULL)
 
 struct port_config {
 	char name[16];


### PR DESCRIPTION
The "set global power budget" command contains a PSE controller in its
argument list. This was hardcoded to 0. On some switches, commands to
PSE 0 do nothing. In those cases, the set budget command won't stick.
The power budget remains at its default value, usually 0. Because of
this, ports remain stuck in the "Requesting power" state.

To solve this, send the budget command to the correct PSE ID or set of
IDs. Use a mask to encode which PSE IDs neet the set budget command.
When the "compatible" devicetree string matches Zyxel GS1900-24HP-v1,
set the mask to 0xff, to command PS ID's 0->7. The vendor firmware
also uses ID's 0->7. This enables power delivery to PoE sinks.
    
![image](https://user-images.githubusercontent.com/2610559/175833634-515c98e6-65f3-45d5-a348-a4e7ef509a93.png)

Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
