### PR TITLE
realtek-poe: Reduce number of port setup packets

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,8 @@
 
 typedef int (*poe_reply_handler)(unsigned char *reply);
 
+/* Careful with this; Only works for set_detection/disconnect_type commands. */
+#define PORT_ID_ALL	0x7f
 #define MAX_PORT	24
 #define GET_STR(a, b)	((a) < ARRAY_SIZE(b) ? (b)[a] : NULL)
 #define MAX(a, b)	(((a) > (b)) ? (a) : (b))
@@ -686,6 +688,9 @@ poe_port_setup(void)
 {
 	size_t i;
 
+	poe_cmd_port_disconnect_type(PORT_ID_ALL, 2);
+	poe_cmd_port_detection_type(PORT_ID_ALL, 3);
+
 	for (i = 0; i < config.port_count; i++) {
 		if (!config.ports[i].enable) {
 			poe_cmd_port_enable(i, 0);
@@ -700,9 +705,7 @@ poe_port_setup(void)
 		} else {
 			poe_cmd_port_power_limit_type(i, 1);
 		}
-		poe_cmd_port_disconnect_type(i, 2);
 		poe_cmd_port_classification(i, 1);
-		poe_cmd_port_detection_type(i, 3);
 		poe_cmd_port_enable(i, 1);
 	}
 


### PR DESCRIPTION
In response to #18, try to be more efficient with port setup.

Use 4 port commands efficiently
------------------------------------------

Most commands used for configuring port parameters can set up tp four
ports per packet. Only setting one port port and setting all other
fields to 0xff is woefully inefficient. How ineffiecient? On a 24-port
switch, each command could be sent in 6 packets instead of 24.

To achieve this, pack 4 port IDs and values in each command, and skip
unused or disabled ports.

I had considered that unpacking an array of structures, to pack into
two arrays to then repack into one array is "woefully inefficient".
The CPU and RAM is 5 orders of magnitude faster than the serial link,
and I was going for the least unreadable approach. I'm open to
improvements as long as it reduces the line count.

Use port ID 0x7f (all ports) where supported
----------------------------------------------------------

The set_port_disconnect_type and set_port_detection_type commands can
configure all ports in one go if passed a port_id of 0x7f. On 24-port
switches, using this approach significantly reduces the number of
packets sent during configuration.

There is no anticipated need to change the config on a per-port basis.
Only send one of each poe_cmd_port_disconnect_type() and
poe_cmd_port_detection_type() commands, with a port ID of 0x7f.

Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>