### PR TITLE
Log MCU errors in the system log

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -553,6 +553,7 @@ poe_reply_consume(unsigned char *reply)
 {
 	struct cmd *cmd = NULL;
 	unsigned char sum = 0, i;
+	uint8_t cmd_id, cmd_seq;
 
 	log_packet(LOG_DEBUG, "RX <-", reply);
 
@@ -563,26 +564,29 @@ poe_reply_consume(unsigned char *reply)
 
 	cmd = list_first_entry(&cmd_pending, struct cmd, list);
 	list_del(&cmd->list);
+	cmd_id = cmd->cmd[0];
+	cmd_seq = cmd->cmd[1];
 
 	for (i = 0; i < 11; i++)
 		sum += reply[i];
 
 	if (reply[11] != sum) {
 		ULOG_DBG("received reply with bad checksum\n");
-		return -1;
-	}
-
-	if ((reply[0] != cmd->cmd[0]) || (reply[0] > ARRAY_SIZE(reply_handler))) {
-		ULOG_DBG("received reply with bad command id\n");
-		return -1;
-	}
-
-	if (reply[1] != cmd->cmd[1]) {
-		ULOG_DBG("received reply with bad sequence number\n");
+		free(cmd);
 		return -1;
 	}
 
 	free(cmd);
+
+	if ((reply[0] != cmd_id) || (reply[0] > ARRAY_SIZE(reply_handler))) {
+		ULOG_DBG("received reply with bad command id\n");
+		return -1;
+	}
+
+	if (reply[1] != cmd_seq) {
+		ULOG_DBG("received reply with bad sequence number\n");
+		return -1;
+	}
 
 	if (reply_handler[reply[0]]) {
 	  return reply_handler[reply[0]](reply);


### PR DESCRIPTION
This is a subset of PR #15. It includes everything needed to log error replies, but drops the retry mechanism.

@Hurricos, I'd like to get this merged soon, so that when issues do pop up, we have some log indication of what happened. It doesn't solve any issue -- just logs the relevant bits:

    logread -te realtek-poe

But wait, there's more! Also found a memory leak that I'm confident is fixed by this PR.