### PR TITLE
Change PoE type setting and autogenerate new configuration files

### DIFF
--- a/files/etc/config/poe
+++ b/files/etc/config/poe
@@ -1,9 +1,0 @@
-config global
-	option budget	'170'
-
-config port
-	option enable	'1'
-	option id	'1'
-	option name	'lan1'
-	option poe_plus	'1'
-	option priority	'2'

--- a/files/etc/uci-defaults/20-realtek-poe-migrate-poe-type
+++ b/files/etc/uci-defaults/20-realtek-poe-migrate-poe-type
@@ -1,0 +1,27 @@
+[ ! -s /etc/config/poe ] && exit 0
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+function migrate_port_poe_type() {
+    local cfg="$1"
+    local poe_plus poe_type
+
+    config_get poe_plus "$cfg" poe_plus ""
+    config_get poe_type "$cfg" poe_type ""
+
+    # Only translate if not already configured
+    if [ -z "$poe_type" ] && [ "$poe_plus" = "1" ]; then
+        uci set "poe.$cfg.poe_type=802.3at"
+    fi
+
+    # Remove deprecated config
+    if [ -n "$poe_plus" ]; then
+        uci delete "poe.$cfg.poe_plus"
+    fi
+}
+
+config_load poe
+config_foreach migrate_port_poe_type
+
+uci commit poe

--- a/files/etc/uci-defaults/30-realtek-poe
+++ b/files/etc/uci-defaults/30-realtek-poe
@@ -1,0 +1,40 @@
+[ -e /etc/config/poe ] && exit 0
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+CFG=/etc/board.json
+
+json_init
+json_load "$(cat ${CFG})"
+
+json_is_a poe object || exit 0
+
+umask 055
+touch /etc/config/poe
+
+json_select poe
+	json_get_vars budget
+
+	uci add poe global
+	uci set poe.@global[-1].budget="$budget"
+
+	if json_is_a ports array; then
+		json_get_values ports ports
+		id='1'
+
+		for port in $ports; do
+			uci -q batch <<-EOF
+				add poe port
+				set poe.@port[-1].name='$port'
+				set poe.@port[-1].id='$id'
+				set poe.@port[-1].enable='1'
+			EOF
+			let id=id+1
+		done
+	fi
+json_select ..
+
+uci commit
+
+exit 0


### PR DESCRIPTION
In order to make the poe config file a bit more generic, which may require multiple types of PoE output types, this PR add two patches that first add support for a new 'poe_type' setting (deprecating 'poe_plus'), followed by a migration script.

Secondly, a script is provided to autogenerate configuration files based on board.json. This replaces the poe config file included in the realtek-poe package.