### PR TITLE
Eliminate global variables and clean up coding style

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@ typedef int (*poe_reply_handler)(unsigned char *reply);
 #define PORT_ID_ALL	0x7f
 #define MAX_RETRIES	5
 
-struct state {
+struct mcu {
 	const char *sys_mode;
 	unsigned char sys_version;
 	const char *sys_mcu;
@@ -54,7 +54,7 @@ struct poe_ctx {
 static struct ustream_fd stream;
 static LIST_HEAD(cmd_pending);
 static unsigned char cmd_seq;
-static struct state state;
+static struct mcu state;
 static struct blob_buf b;
 
 static void config_apply_quirks(struct config *config);

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+
+#ifndef TEK_POE_H
+#define TEK_POE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <libubox/utils.h>
+
+#define ULOG_DBG(fmt, ...) ulog(LOG_DEBUG, fmt, ## __VA_ARGS__)
+
+#define GET_STR(a, b)	((a) < ARRAY_SIZE(b) ? (b)[a] : NULL)
+#define MAX(a, b)	(((a) > (b)) ? (a) : (b))
+#define MAX_PORT	48
+
+struct port_state {
+	const char *status;
+	float watt;
+	const char *poe_mode;
+};
+
+struct port_config {
+	char name[16];
+	unsigned int valid : 1;
+	unsigned int enable : 1;
+	uint8_t priority;
+	uint8_t power_up_mode;
+	uint8_t power_budget;
+};
+
+struct config {
+	float budget;
+	float budget_guard;
+
+	unsigned int port_count;
+	uint8_t pse_id_set_budget_mask;
+	struct port_config ports[MAX_PORT];
+};
+
+static inline uint16_t read16_be(uint8_t *raw)
+{
+	return (uint16_t)raw[0] << 8 | raw[1];
+}
+
+static inline void write16_be(uint8_t *raw, uint16_t value)
+{
+	raw[0] = value >> 8;
+	raw[1] =  value & 0xff;
+}
+
+#endif /* TEK_POE_H */

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -19,6 +19,18 @@ struct port_state {
 	const char *poe_mode;
 };
 
+struct mcu_state {
+	const char *sys_mode;
+	uint8_t sys_version;
+	const char *sys_mcu;
+	const char *sys_status;
+	uint8_t sys_ext_version;
+	float power_consumption;
+	unsigned int num_detected_ports;
+
+	struct port_state ports[MAX_PORT];
+};
+
 struct port_config {
 	char name[16];
 	unsigned int valid : 1;


### PR DESCRIPTION
The original realtek-poe contained a tonne of global variables. I never liked that approach, but it also didn't really get in the way. Thus there was no immediate need to invest a large effort to refactor the passing of arguments.

However, this really started to bite us in the ass when looking at adding another dialect in #25 . It makes splitting code into different files difficult, and causes a bunch of maintainability  issues that  I don't list here.

So let's improve the situation, and use proper contexts throughout realtek-poe.