### PR TITLE
Increase MAX_PORT to 48 for larger devices

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@ typedef int (*poe_reply_handler)(unsigned char *reply);
 
 /* Careful with this; Only works for set_detection/disconnect_type commands. */
 #define PORT_ID_ALL	0x7f
-#define MAX_PORT	24
+#define MAX_PORT	48
 #define MAX_RETRIES	5
 #define GET_STR(a, b)	((a) < ARRAY_SIZE(b) ? (b)[a] : NULL)
 #define MAX(a, b)	(((a) > (b)) ? (a) : (b))


### PR DESCRIPTION
This accommodates the HPE 1920-48G-PoE (JG928A) 48-port PoE switch. Increasing MAX_PORT only requires a bit more stack memory for all platforms -- we don't for example do any kind of repeated discovery iterating over this variable, so there's no real downside here.

The upside is, of course, supporting these platforms.