### PR TITLE
realtek-poe/openwrt: Generate config from board.json

### DIFF
--- a/files/etc/uci-defaults/30-poe
+++ b/files/etc/uci-defaults/30-poe
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[ -e /etc/config/poe ] && exit 0
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+CFG=/etc/board.json
+
+json_init
+json_load_file "${CFG}"
+
+json_is_a poe object || exit 0
+
+umask 055
+touch /etc/config/poe
+
+json_select poe
+	json_get_vars budget
+
+	uci add poe global
+	uci set poe.@global[-1].budget="$budget"
+
+	if json_is_a ports array; then
+		json_get_values ports ports
+		id='1'
+
+		for port in $ports; do
+			uci -q batch <<-EOF
+				add poe port
+				set poe.@port[-1].name='$port'
+				set poe.@port[-1].id='$id'
+				set poe.@port[-1].enable='1'
+			EOF
+			let id=id+1
+		done
+	fi
+json_select ..
+
+uci commit
+
+exit 0


### PR DESCRIPTION
Styled after work provided by @svanheule, then reiterated by @howels.

Before this commit, realtek-poe maintainers prioritized keeping realtek-poe simple; it was "[a tool to] take a config file and control the hardware ... [which speaks] UCI config on one end, and PoE protocol on the other"[^1]. We declined to support generating that config file previously.

OpenWrt maintainer @blogic firmly disagreed[^2], because OpenWrt users were finding their devices starting with non-functional PoE (which is a violation of the principle of least surprise).

It's been about a year since a solution to this problem was first provided[^3].

Change stance. Now, begin generating /etc/config/poe from board.json under OpenWrt (our only supported platform). It's in the community's best interest to at least provide a stop-gap until either:

- other software actually uses realtek-poe outside of OpenWrt, or
- another OpenWrt package uses /etc/config/poe to configure these PSEs

at which point I'll revisit and do the integration work.

A companion commit will be required to openwrt/packages.git.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>

[^1]: https://github.com/Hurricos/realtek-poe/issues/41#issuecomment-2426670039

[^2]: https://github.com/openwrt/openwrt/pull/16838#issuecomment-2542114739

[^3]: https://github.com/Hurricos/realtek-poe/pull/31

Replaces: #31