### PR TITLE
.github/workflows: Appease the github gods and use "v4"

### DIFF
--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
             "
 
       - name: Store packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mips_4kec-packages
           path: bin/packages/mips_4kec/base/realtek-poe_*.ipk


### PR DESCRIPTION
Apparently, some numbnut at github decided to make the actions versioned. So although we have a perfectly working github pipeline, we need to keep updating it whenever the github powers decide to deprecate a number.

So update the "checkout" action from v2, to the diety-approved v4.