### PR TITLE
realtek-poe: info: add voltage, current and temperature

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -498,6 +498,9 @@ static int poe_reply_port_power_stats(struct mcu_state *state, uint8_t *reply)
 {
 	int port_idx = reply[2];
 
+	state->ports[port_idx].mvolt = read16_be(reply + 3) * 64.45;
+	state->ports[port_idx].mampere = read16_be(reply + 5);
+	state->ports[port_idx].tempc = (220 - read16_be(reply + 7)) * 1.25;
 	state->ports[port_idx].watt = read16_be(reply + 9) * 0.1;
 	return 0;
 }
@@ -806,6 +809,12 @@ static int ubus_poe_info_cb(struct ubus_context *ctx, struct ubus_object *obj,
 			blobmsg_add_string(b, "status", state->ports[i].status);
 		else
 			blobmsg_add_string(b, "status", "unknown");
+		if (state->ports[i].mvolt)
+			blobmsg_add_double(b, "voltage", state->ports[i].mvolt / 1000.0);
+		if (state->ports[i].mampere)
+			blobmsg_add_double(b, "current", state->ports[i].mampere / 1000.0);
+		if (state->ports[i].tempc)
+			blobmsg_add_double(b, "temperature", state->ports[i].tempc);
 		if (state->ports[i].watt)
 			blobmsg_add_double(b, "consumption", state->ports[i].watt);
 

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -15,6 +15,9 @@
 
 struct port_state {
 	const char *status;
+	float mvolt;
+	float mampere;
+	float tempc;
 	float watt;
 	const char *poe_mode;
 };


### PR DESCRIPTION
Expose voltage, current and temperature readings from each port.

On my HPE-1920 JG926A the values are returned and contain seemingly useful data:

       "lan3": {
        "priority": 2,
        "mode": "PoE+",
        "status": "Delivering power",
        "voltage": 52.397852,
        "current": 0.091000,
        "temperature": 20.000000,
        "consumption": 4.700000
       },
...
       "lan13": {
        "priority": 2,
        "mode": "PoE+",
        "status": "Delivering power",
        "voltage": 52.462301,
        "current": 0.092000,
        "temperature": 21.250000,
        "consumption": 4.800000
       },
...
       "lan23": {
        "priority": 2,
        "mode": "PoE+",
        "status": "Searching",
        "temperature": 11.250000
       },

The temperature seems to be always available, and per block of 8 (controller?) the same value.  The values make sense (in Celcius) and I guess could be used to detect overheating and taking actions (up the fans, disable power output).

The voltage and current are just nice to have, and since it's available for free anyway, why not.