### PR TITLE
Add a "debug" command to expose internal PoE state

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -415,6 +415,32 @@ static int poe_reply_status(struct mcu_state *state, uint8_t *reply)
 	return 0;
 }
 
+/* 0x21 - Get port status */
+static int poe_cmd_port_status(struct mcu *mcu, uint8_t port)
+{
+	uint8_t cmd[] = { 0x21, 0x00, port };
+
+	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
+}
+
+static int poe_reply_port_status(struct mcu_state *state, uint8_t *reply)
+{
+	unsigned int idx = reply[2];
+	struct port_state *port = &state->ports[idx];
+
+	if (idx > state->num_detected_ports) {
+		ULOG_WARN("Invalid port in status reply (port=%d)\n", idx);
+		return -EPROTO;
+	}
+
+	port->class_info = reply[5];
+	port->pd_type = reply[6];
+	port->mpss_mask = reply[7];
+	port->has_detailed_state = 1;
+
+	return 0;
+}
+
 /* 0x23 - Get power statistics */
 static int poe_cmd_power_stats(struct mcu *mcu)
 {
@@ -427,6 +453,35 @@ static int poe_reply_power_stats(struct mcu_state *state, uint8_t *reply)
 {
 	state->power_consumption = read16_be(reply + 2) * 0.1;
 	state->reported_power_budget = read16_be(reply + 4) * 0.1;
+
+	return 0;
+}
+
+/* 0x25 - Get port config */
+static int poe_cmd_port_config(struct mcu *mcu, uint8_t port)
+{
+	uint8_t cmd[] = { 0x25, 0x00, port };
+
+	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
+}
+
+static int poe_reply_port_config(struct mcu_state *state, uint8_t *reply)
+{
+	unsigned int idx = reply[2];
+	struct port_state *port = &state->ports[idx];
+
+	if (idx > state->num_detected_ports) {
+		ULOG_WARN("Invalid port in config reply (port=%d)\n", idx);
+		return -EPROTO;
+	}
+
+	port->enabled = reply[3];
+	port->auto_powerup = reply[4];
+	port->detection_type = reply[5];
+	port->classification_enable = reply[6];
+	port->disconnect_type = reply[7];
+	port->pair = reply[8];
+	port->has_config_info = 1;
 
 	return 0;
 }
@@ -506,6 +561,28 @@ static int poe_reply_4_port_status(struct mcu_state *state, uint8_t *reply)
 	return 0;
 }
 
+/* 0x2b - Get extended device config */
+static int poe_cmd_get_extended_config(struct mcu *mcu)
+{
+	uint8_t cmd[] = { 0x2b };
+
+	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
+}
+
+static int poe_reply_extended_config(struct mcu_state *state, uint8_t *reply)
+{
+	state->uvlo_threshold = reply[2] * 0.06445 + 33.0;
+	state->pre_alloc = reply[3];
+	state->powerup_mode = reply[4];
+	state->disconnect_type = reply[5];
+	state->ddflag = reply[6];
+	state->ovlo_threshold = reply[7] * 0.06445 + 57.0;
+	state->num_pse = reply[8];
+	state->has_ext_cfg_info = 1;
+
+	return 0;
+}
+
 /* 0x30 - Get port power statistics */
 static int poe_cmd_port_power_stats(struct mcu *mcu, uint8_t port)
 {
@@ -524,9 +601,12 @@ static int poe_reply_port_power_stats(struct mcu_state *state, uint8_t *reply)
 
 static poe_reply_handler reply_handler[] = {
 	[0x20] = poe_reply_status,
+	[0x21] = poe_reply_port_status,
 	[0x23] = poe_reply_power_stats,
 	[0x26] = poe_reply_port_ext_config,
+	[0x25] = poe_reply_port_config,
 	[0x28] = poe_reply_4_port_status,
+	[0x2b] = poe_reply_extended_config,
 	[0x30] = poe_reply_port_power_stats,
 };
 
@@ -775,11 +855,18 @@ static void state_timeout_cb(struct uloop_timeout *t)
 	size_t i;
 
 	poe_cmd_power_stats(mcu);
+	if (poe->hardcore_hacking_mode_en)
+		poe_cmd_get_extended_config(mcu);
 
 	for (i = 0; i < cfg->port_count; i += 4)
 		poe_cmd_4_port_status(mcu, i, i + 1, i + 2, i + 3);
 
 	for (i = 0; i < cfg->port_count; i++) {
+		if (poe->hardcore_hacking_mode_en) {
+			poe_cmd_port_status(mcu, i);
+			poe_cmd_port_config(mcu, i);
+		}
+
 		poe_cmd_port_ext_config(mcu, i);
 		poe_cmd_port_power_stats(mcu, i);
 	}
@@ -858,6 +945,16 @@ static int ubus_poe_debug_cb(struct ubus_context *ctx, struct ubus_object *obj,
 	blobmsg_add_u32(b, "port_map_en", state->port_map_en);
 	blobmsg_add_u32(b, "device_id", state->device_id);
 
+	if (state->has_ext_cfg_info) {
+		blobmsg_add_double(b, "uvlo_threshold", state->uvlo_threshold);
+		blobmsg_add_double(b, "ovlo_threshold", state->ovlo_threshold);
+		blobmsg_add_u32(b, "pre_alloc", state->pre_alloc);
+		blobmsg_add_u32(b, "powerup_mode", state->powerup_mode);
+		blobmsg_add_u32(b, "disconnect_type", state->disconnect_type);
+		blobmsg_add_u32(b, "ddflag", state->ddflag);
+		blobmsg_add_u32(b, "num_pse", state->num_pse);
+	}
+
 	c = blobmsg_open_table(b, "ports");
 	for (i = 0; i < cfg->port_count; i++) {
 		if (!cfg->ports[i].valid)
@@ -870,6 +967,21 @@ static int ubus_poe_debug_cb(struct ubus_context *ctx, struct ubus_object *obj,
 		blobmsg_add_u32(b, "priority", state->ports[i].priority);
 		blobmsg_add_u32(b, "primary_pse_output", state->ports[i].primary_pse_output);
 		blobmsg_add_u32(b, "mapping", state->ports[i].mapping);
+
+		if (state->ports[i].has_config_info) {
+			blobmsg_add_u32(b, "enabled", state->ports[i].enabled);
+			blobmsg_add_u32(b, "auto_powerup", state->ports[i].auto_powerup);
+			blobmsg_add_u32(b, "detection_type", state->ports[i].detection_type);
+			blobmsg_add_u32(b, "classification_enable", state->ports[i].classification_enable);
+			blobmsg_add_u32(b, "disconnect_type", state->ports[i].disconnect_type);
+			blobmsg_add_u32(b, "pair", state->ports[i].pair);
+		}
+
+		if (state->ports[i].has_detailed_state) {
+			blobmsg_add_u32(b, "class_info", state->ports[i].class_info);
+			blobmsg_add_u32(b, "pd_type", state->ports[i].pd_type);
+			blobmsg_add_u32(b, "mpss_mask", state->ports[i].mpss_mask);
+		}
 
 		blobmsg_close_table(b, p);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -405,6 +405,8 @@ static int poe_reply_status(struct mcu_state *state, uint8_t *reply)
 
 	state->sys_mode = GET_STR(reply[2], mode);
 	state->num_detected_ports = reply[3];
+	state->port_map_en = reply[4];
+	state->device_id =  read16_be(reply + 5);
 	state->sys_version = reply[7];
 	state->sys_mcu = GET_STR(reply[8], mcu_names);
 	state->sys_status = GET_STR(reply[9], status);
@@ -424,6 +426,7 @@ static int poe_cmd_power_stats(struct mcu *mcu)
 static int poe_reply_power_stats(struct mcu_state *state, uint8_t *reply)
 {
 	state->power_consumption = read16_be(reply + 2) * 0.1;
+	state->reported_power_budget = read16_be(reply + 4) * 0.1;
 
 	return 0;
 }
@@ -438,6 +441,9 @@ static int poe_cmd_port_ext_config(struct mcu *mcu, uint8_t port)
 
 static int poe_reply_port_ext_config(struct mcu_state *state, uint8_t *reply)
 {
+	unsigned int idx = reply[2];
+	struct port_state *port = &state->ports[idx];
+
 	const char *mode[] = {
 		"PoE",
 		"Legacy",
@@ -445,7 +451,18 @@ static int poe_reply_port_ext_config(struct mcu_state *state, uint8_t *reply)
 		"PoE+"
 	};
 
-	state->ports[reply[2]].poe_mode = GET_STR(reply[3], mode);
+	if (idx > state->num_detected_ports) {
+		ULOG_WARN("Invalid port in ext config reply (port=%d)\n", idx);
+		return -EPROTO;
+	}
+
+	port->poe_mode = GET_STR(reply[3], mode);
+	port->power_limit_type = reply[4];
+	port->power_budget = reply[5] * 0.2;
+	port->priority = reply[6];
+	port->primary_pse_output = reply[7];
+	/* In the broadcom dialect, pse output and mapping are synonymous. */
+	port->mapping = port->primary_pse_output;
 
 	return 0;
 }
@@ -821,6 +838,58 @@ static int ubus_poe_info_cb(struct ubus_context *ctx, struct ubus_object *obj,
 	return UBUS_STATUS_OK;
 }
 
+static int ubus_poe_debug_cb(struct ubus_context *ctx, struct ubus_object *obj,
+			    struct ubus_request_data *req, const char *method,
+			    struct blob_attr *msg)
+{
+	struct poe_ctx *poe = ubus_to_poe_ctx(ctx);
+	const struct mcu_state *state = &poe->mcu.state;
+	const struct config *cfg = &poe->config;
+	struct blob_buf *b = &poe->blob_buf;
+	size_t i;
+	void *c, *p;
+
+	blob_buf_init(b, 0);
+
+	blobmsg_add_double(b, "reported_budget", state->reported_power_budget);
+
+
+	blobmsg_add_u32(b, "num_detected_ports", state->num_detected_ports);
+	blobmsg_add_u32(b, "port_map_en", state->port_map_en);
+	blobmsg_add_u32(b, "device_id", state->device_id);
+
+	c = blobmsg_open_table(b, "ports");
+	for (i = 0; i < cfg->port_count; i++) {
+		if (!cfg->ports[i].valid)
+			continue;
+
+		p = blobmsg_open_table(b, cfg->ports[i].name);
+
+		blobmsg_add_u32(b, "power_limit_type", state->ports[i].power_limit_type);
+		blobmsg_add_double(b, "power_budget", state->ports[i].power_budget);
+		blobmsg_add_u32(b, "priority", state->ports[i].priority);
+		blobmsg_add_u32(b, "primary_pse_output", state->ports[i].primary_pse_output);
+		blobmsg_add_u32(b, "mapping", state->ports[i].mapping);
+
+		blobmsg_close_table(b, p);
+	}
+	blobmsg_close_table(b, c);
+
+	p = blobmsg_open_table(b, "mapping");
+	blobmsg_add_u32(b, "enabled", state->port_map_en);
+	for (i = 0; i < cfg->port_count; i++) {
+		if (!cfg->ports[i].valid)
+			continue;
+
+		blobmsg_add_u32(b, cfg->ports[i].name, state->ports[i].mapping);
+	}
+	blobmsg_close_table(b, p);
+
+	ubus_send_reply(ctx, req, b->head);
+
+	return UBUS_STATUS_OK;
+}
+
 static const struct blobmsg_policy ubus_poe_sendframe_policy[] = {
 	{ "frame", BLOBMSG_TYPE_STRING },
 };
@@ -913,6 +982,7 @@ static int ubus_poe_manage_cb(struct ubus_context *ctx, struct ubus_object *obj,
 
 static const struct ubus_method ubus_poe_methods[] = {
 	UBUS_METHOD_NOARG("info", ubus_poe_info_cb),
+	UBUS_METHOD_NOARG("debug", ubus_poe_debug_cb),
 	UBUS_METHOD_NOARG("reload", ubus_poe_reload_cb),
 	UBUS_METHOD("sendframe", ubus_poe_sendframe_cb, ubus_poe_sendframe_policy),
 	UBUS_METHOD("manage", ubus_poe_manage_cb, ubus_poe_manage_policy),

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -16,7 +16,13 @@
 struct port_state {
 	const char *status;
 	const char *poe_mode;
+	float power_budget;
 	float watt;
+
+	uint8_t power_limit_type;
+	uint8_t priority;
+	uint8_t primary_pse_output;
+	uint8_t mapping;
 };
 
 struct mcu_state {
@@ -24,9 +30,12 @@ struct mcu_state {
 	const char *sys_mcu;
 	const char *sys_status;
 	float power_consumption;
+	float reported_power_budget;
 	unsigned int num_detected_ports;
+	uint16_t device_id;
 	uint8_t sys_version;
 	uint8_t sys_ext_version;
+	uint8_t port_map_en;
 
 	struct port_state ports[MAX_PORT];
 };

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -15,18 +15,18 @@
 
 struct port_state {
 	const char *status;
-	float watt;
 	const char *poe_mode;
+	float watt;
 };
 
 struct mcu_state {
 	const char *sys_mode;
-	uint8_t sys_version;
 	const char *sys_mcu;
 	const char *sys_status;
-	uint8_t sys_ext_version;
 	float power_consumption;
 	unsigned int num_detected_ports;
+	uint8_t sys_version;
+	uint8_t sys_ext_version;
 
 	struct port_state ports[MAX_PORT];
 };

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -19,10 +19,24 @@ struct port_state {
 	float power_budget;
 	float watt;
 
+	unsigned int has_config_info : 1;
+	unsigned int has_detailed_state : 1;
+
 	uint8_t power_limit_type;
 	uint8_t priority;
 	uint8_t primary_pse_output;
 	uint8_t mapping;
+
+	uint8_t enabled;
+	uint8_t auto_powerup;
+	uint8_t detection_type;
+	uint8_t classification_enable;
+	uint8_t disconnect_type;
+	uint8_t pair;
+
+	uint8_t class_info;
+	uint8_t pd_type;
+	uint8_t mpss_mask;
 };
 
 struct mcu_state {
@@ -31,11 +45,22 @@ struct mcu_state {
 	const char *sys_status;
 	float power_consumption;
 	float reported_power_budget;
+	float uvlo_threshold;
+	float ovlo_threshold;
 	unsigned int num_detected_ports;
+
+	unsigned int has_ext_cfg_info : 1;
+
 	uint16_t device_id;
 	uint8_t sys_version;
 	uint8_t sys_ext_version;
 	uint8_t port_map_en;
+
+	uint8_t pre_alloc;
+	uint8_t powerup_mode;
+	uint8_t disconnect_type;
+	uint8_t ddflag;
+	uint8_t num_pse;
 
 	struct port_state ports[MAX_PORT];
 };


### PR DESCRIPTION
The PoE controller has a lot of debug info that might be useful for troubleshooting. Add a new `debug` command to expose other information which is not directly relevant to ports or connected PoE sinks.

More details in individual commit messages.