### PR TITLE
realtek-poe: port_ext_config: move from timeout loop to setup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -816,8 +816,10 @@ static int poe_port_setup(struct mcu* mcu, const struct config *cfg)
 
 	poet_setup(mcu, cfg->ports, cfg->port_count);
 
-	for (i = 0; i < cfg->port_count; i++)
+	for (i = 0; i < cfg->port_count; i++) {
 		poe_cmd_port_enable(mcu, i, !!cfg->ports[i].enable);
+		poe_cmd_port_ext_config(mcu, i);
+	}
 
 	return 0;
 }
@@ -854,6 +856,12 @@ static void state_timeout_cb(struct uloop_timeout *t)
 	struct mcu *mcu = &poe->mcu;
 	size_t i;
 
+	/* skip this iteration if we're still busy processing the queue */
+	if (!list_empty(&mcu->pending_cmds)) {
+		uloop_timeout_set(t, 1 * 1000);
+		return;
+	}
+
 	poe_cmd_power_stats(mcu);
 	if (poe->hardcore_hacking_mode_en)
 		poe_cmd_get_extended_config(mcu);
@@ -867,7 +875,6 @@ static void state_timeout_cb(struct uloop_timeout *t)
 			poe_cmd_port_config(mcu, i);
 		}
 
-		poe_cmd_port_ext_config(mcu, i);
 		poe_cmd_port_power_stats(mcu, i);
 	}
 


### PR DESCRIPTION
Reduce traffic/stress (and thus cpu intensity/load) a bit by not retrieving extended port config all the time.  The only thing we currently monitor is the powerup mode, which won't change unless we set it.  So move it to setup where it will be re-run if the config changes.