### PR TITLE
realtek-poe: manage: fix return value on command success

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -905,7 +905,7 @@ static int ubus_poe_manage_cb(struct ubus_context *ctx, struct ubus_object *obj,
 			continue;
 		return poe_cmd_port_enable(mcu, i, blobmsg_get_bool(tb[1]));
 	}
-	return UBUS_STATUS_INVALID_ARGUMENT;
+	return UBUS_STATUS_OK;
 }
 
 static const struct ubus_method ubus_poe_methods[] = {


### PR DESCRIPTION
The `ubus call poe manage ...` command returns with an error message:
  "Command failed: Parsing message data failed"

That is obviosly incorrect, and is caused by ubus_poe_manage_cb(), which returns UBUS_STATUS_INVALID_ARGUMENT instead of UBUS_STATUS_OK on success.

Change the last return code to UBUS_STATUS_OK.

Fixes: 39c93d39dd10 ("realtek-poe: add ubus dynamic port management")