### PR TITLE
realtek-poe: remove commandline argument for baudrate

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1276,14 +1276,12 @@ int main(int argc, char **argv)
 	ulog_open(ULOG_STDIO | ULOG_SYSLOG, LOG_DAEMON, "realtek-poe");
 	ulog_threshold(LOG_INFO);
 
-	while ((ch = getopt(argc, argv, "ds")) != -1) {
+	while ((ch = getopt(argc, argv, "d")) != -1) {
 		switch (ch) {
 		case 'd':
 			ulog_threshold(LOG_DEBUG);
 			poe.hardcore_hacking_mode_en = 1;
 			break;
-		case 'f':
-			baudrate = 115200;
 		}
 	}
 
@@ -1298,10 +1296,8 @@ int main(int argc, char **argv)
 	/* Users of poe_dialect assume the reverse mapping is computed. */
 	dialect_reverse_map(&poe.mcu.dialect);
 
-	/* Prefer '-s' argument over any config file option */
-	if (baudrate) {
-		/* Keep existing baudrate */
-	} else if (poe.config.forced_baudrate) {
+	/* Temporarily allow config file to override baudrate */
+	if (poe.config.forced_baudrate) {
 		baudrate = poe.config.forced_baudrate;
 	} else {
 		baudrate = 19200;


### PR DESCRIPTION
Commit e58055c ("tek-poe: allow changing baudrate dialect in the config") introduced two ways to override the default baudrate. Having a commandline parameter to change the baudrate was useful during development, but should not have been committed otherwise. This function does not work due to a typo in the getopt() arguments.

The design philosophy of realtek-poe is that it should work with minimal configuration. Because an auto-detection mechanism is not currently implemented, the baudrate needs to be configured by the user. However doing so from two inputs could be confusing.

Remove the commandline argument to prevent confusion. The `force_baudrate` config option be used instead.

Fixes: e58055c ("tek-poe: allow changing baudrate dialect in the config")