### PR TITLE
build: require CMake >= 3.10 due to dropped legacy support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 PROJECT(realtek-poe C)
 ADD_DEFINITIONS(-Os -ggdb -Wextra -Wall -Werror --std=gnu99 -Wmissing-declarations -Wno-unused-parameter)


### PR DESCRIPTION
CMake version 4.0 and later require minimum version of 3.5 or later. Update to minimum version 3.10 which is the last not deprecated minimum version.

CMake 3.10 was released in November 2017 and is included in Ubuntu 18.04.