### PR TITLE
Add ability to map leds to match remapped ports

### DIFF
--- a/files/etc/config/poe
+++ b/files/etc/config/poe
@@ -1,5 +1,6 @@
 config global
 	option budget	'170'
+	option map_leds '1'
 
 config port
 	option enable	'1'

--- a/src/dialect_bcm.c
+++ b/src/dialect_bcm.c
@@ -23,6 +23,9 @@ static const struct dialect_map_entry bcm_dialect_mapping[] = {
 	[PORT_GET_EXT_CONFIG]		= {0x26, 1},
 	[PORT_GET_SHORT_STATUS]		= {0x28, CMD_IS_4PORT},
 	[PORT_GET_POWER_STATS]		= {0x30, 1},
+
+	[PORT_GET_LED_MAP]		= {0x49, 1},
+	[PORT_SET_LED_MAP]		= {0x48, 1},
 };
 
 static const struct dialect_map bcm_dialect_map = {

--- a/src/main.c
+++ b/src/main.c
@@ -463,8 +463,6 @@ static int poe_reply_port_led_map(struct mcu_state *state, uint8_t *reply)
 		led_index[i] = reply[3 + i];
 	}
 
-	ULOG_ERR("LED MAP: PORT_OFFSET=%d LED_INDEX[0]=%d LED_INDEX[1]=%d LED_INDEX[2]=%d LED_INDEX[3]=%d LED_INDEX[4]=%d LED_INDEX[5]=%d LED_INDEX[6]=%d LED_INDEX[7]=%d", port_offset, led_index[0], led_index[1], led_index[2], led_index[3], led_index[4], led_index[5], led_index[6], led_index[7]);
-
 	return 0;
 }
 
@@ -479,20 +477,6 @@ static int poe_port_set_led_map(struct mcu *mcu, uint8_t port_offset)
 	}
 
 	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
-}
-
-static int poe_reply_port_set_led_map(struct mcu_state *state, uint8_t *reply)
-{
-	unsigned int port_offset = reply[2];
-
-	unsigned int led_index[8];
-	for (uint8_t i = 0; i < 8; i++) {
-		led_index[i] = reply[3 + i];
-	}
-
-	ULOG_ERR("LED MAP SET REPLY: PORT_OFFSET=%d LED_INDEX[0]=%d LED_INDEX[1]=%d LED_INDEX[2]=%d LED_INDEX[3]=%d LED_INDEX[4]=%d LED_INDEX[5]=%d LED_INDEX[6]=%d LED_INDEX[7]=%d", port_offset, led_index[0], led_index[1], led_index[2], led_index[3], led_index[4], led_index[5], led_index[6], led_index[7]);
-
-	return 0;
 }
 
 /* 0x20 - Get system info */
@@ -777,7 +761,7 @@ static poe_reply_handler reply_handler[] = {
 	[PORT_GET_EXT_CONFIG]		= poe_reply_port_ext_config,
 	[MCU_GET_EXT_CONFIG]		= poe_reply_extended_config,
 	[PORT_GET_LED_MAP]		=  poe_reply_port_led_map,
-	[PORT_SET_LED_MAP]		=  poe_reply_port_set_led_map,
+	[PORT_SET_LED_MAP]		=  poe_reply_port_led_map,
 };
 
 static void mcu_clear_timeout(struct uloop_timeout *t)

--- a/src/main.c
+++ b/src/main.c
@@ -456,12 +456,12 @@ static int poe_set_port_power_up_mode(struct mcu *mcu, uint8_t port[4],
 
 static int poe_reply_port_led_map(struct mcu_state *state, uint8_t *reply)
 {
-	unsigned int port_offset = reply[2];
+	/*unsigned int port_offset = reply[2];
 
 	unsigned int led_index[8];
 	for (uint8_t i = 0; i < 8; i++) {
 		led_index[i] = reply[3 + i];
-	}
+	}*/
 
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -108,12 +108,13 @@ static void load_global_config(struct config *cfg, struct uci_context *uci,
 			       struct uci_section *s)
 
 {
-	const char *budget, *guardband, *baudrate_hack, *dialect_hack;
+	const char *budget, *guardband, *baudrate_hack, *dialect_hack, *map_leds;
 
 	budget = uci_lookup_option_string(uci, s, "budget");
 	guardband = uci_lookup_option_string(uci, s, "guard");
 	baudrate_hack = uci_lookup_option_string(uci, s, "force_baudrate");
 	dialect_hack = uci_lookup_option_string(uci, s, "force_dialect");
+	map_leds = uci_lookup_option_string(uci, s, "map_leds");
 
 	cfg->budget = budget ? strtof(budget, NULL) : 31.0;
 	cfg->budget_guard = cfg->budget / 10;
@@ -134,6 +135,8 @@ static void load_global_config(struct config *cfg, struct uci_context *uci,
 		else
 			ULOG_ERR("Unkown dialect '%s'\n", dialect_hack);
 	}
+
+	cfg->map_leds = map_leds ? !strcmp(map_leds, "1") : 0;
 }
 
 static char *get_board_compatible(void)
@@ -443,6 +446,55 @@ static int poe_set_port_power_up_mode(struct mcu *mcu, uint8_t port[4],
 	return poet_cmd_4_port(mcu, PORT_SET_POE_MODE, port, mode);
 }
 
+/* 0x49 - Get port led map */
+/*static int poe_port_led_map(struct mcu *mcu, uint8_t port_offset)
+{
+	uint8_t cmd[] = { PORT_GET_LED_MAP, 0x00, port_offset };
+
+	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
+}*/
+
+static int poe_reply_port_led_map(struct mcu_state *state, uint8_t *reply)
+{
+	unsigned int port_offset = reply[2];
+
+	unsigned int led_index[8];
+	for (uint8_t i = 0; i < 8; i++) {
+		led_index[i] = reply[3 + i];
+	}
+
+	ULOG_ERR("LED MAP: PORT_OFFSET=%d LED_INDEX[0]=%d LED_INDEX[1]=%d LED_INDEX[2]=%d LED_INDEX[3]=%d LED_INDEX[4]=%d LED_INDEX[5]=%d LED_INDEX[6]=%d LED_INDEX[7]=%d", port_offset, led_index[0], led_index[1], led_index[2], led_index[3], led_index[4], led_index[5], led_index[6], led_index[7]);
+
+	return 0;
+}
+
+
+/* 0x49 - Set port led map */
+static int poe_port_set_led_map(struct mcu *mcu, uint8_t port_offset)
+{
+	uint8_t cmd[11] = { PORT_SET_LED_MAP, 0x00, port_offset };
+
+	for (uint8_t i = 0; i < 8; i++) {
+		cmd[3 + i] = port_offset + i;
+	}
+
+	return mcu_queue_cmd(mcu, cmd, sizeof(cmd));
+}
+
+static int poe_reply_port_set_led_map(struct mcu_state *state, uint8_t *reply)
+{
+	unsigned int port_offset = reply[2];
+
+	unsigned int led_index[8];
+	for (uint8_t i = 0; i < 8; i++) {
+		led_index[i] = reply[3 + i];
+	}
+
+	ULOG_ERR("LED MAP SET REPLY: PORT_OFFSET=%d LED_INDEX[0]=%d LED_INDEX[1]=%d LED_INDEX[2]=%d LED_INDEX[3]=%d LED_INDEX[4]=%d LED_INDEX[5]=%d LED_INDEX[6]=%d LED_INDEX[7]=%d", port_offset, led_index[0], led_index[1], led_index[2], led_index[3], led_index[4], led_index[5], led_index[6], led_index[7]);
+
+	return 0;
+}
+
 /* 0x20 - Get system info */
 static int poe_cmd_status(struct mcu *mcu)
 {
@@ -724,6 +776,8 @@ static poe_reply_handler reply_handler[] = {
 	[PORT_GET_CONFIG]		= poe_reply_port_config,
 	[PORT_GET_EXT_CONFIG]		= poe_reply_port_ext_config,
 	[MCU_GET_EXT_CONFIG]		= poe_reply_extended_config,
+	[PORT_GET_LED_MAP]		=  poe_reply_port_led_map,
+	[PORT_SET_LED_MAP]		=  poe_reply_port_set_led_map,
 };
 
 static void mcu_clear_timeout(struct uloop_timeout *t)
@@ -944,6 +998,11 @@ static int poe_port_setup(struct mcu* mcu, const struct config *cfg)
 	for (i = 0; i < cfg->port_count; i++) {
 		poe_cmd_port_enable(mcu, i, !!cfg->ports[i].enable);
 		poe_cmd_port_ext_config(mcu, i);
+
+		if (i % 8 == 0 && cfg->map_leds) {
+			poe_port_set_led_map(mcu, i);
+			//poe_port_led_map(mcu, i);
+		}
 	}
 
 	return 0;

--- a/src/tek-poe.h
+++ b/src/tek-poe.h
@@ -44,7 +44,9 @@ enum poe_cmd {
 	PORT_GET_STATUS,
 	PORT_GET_SHORT_STATUS,
 	PORT_GET_POWER_STATS,
-	CMD_MAX
+	CMD_MAX,
+	PORT_GET_LED_MAP,
+	PORT_SET_LED_MAP
 };
 
 enum poe_cmd_flags {
@@ -124,6 +126,7 @@ struct config {
 	float budget;
 	float budget_guard;
 
+	unsigned int map_leds : 1;
 	unsigned int forced_baudrate;
 	unsigned int port_count;
 	uint8_t pse_id_set_budget_mask;


### PR DESCRIPTION
This change adds a _map_leds_ config option to remap the LEDs to match the _id_ mapping.
This is currently needed on Netgear GS110TPPv1 in order to fix the PoE LEDs after reversing the port order to match the port numbering on the device.

My config as an example:
```
config global
        option budget   '120'
        option map_leds '1'

config port
        option enable   '1'
        option id       '1'
        option name     'lan8'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '2'
        option name     'lan7'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '3'
        option name     'lan6'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '4'
        option name     'lan5'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '5'
        option name     'lan4'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '6'
        option name     'lan3'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '7'
        option name     'lan2'
        option poe_plus '1'
        option priority '2'

config port
        option enable   '1'
        option id       '8'
        option name     'lan1'
        option poe_plus '1'
        option priority '2'
```
