### PR TITLE
realtek-poe: add PSE ID quirk for Zyxel GS1900-48HP A1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -169,6 +169,11 @@ static void config_apply_quirks(struct config *config)
 		config->pse_id_set_budget_mask = 0xff;
 	}
 
+	if (!strcmp(compatible, "zyxel,gs1900-48hp-a1")) {
+		/* Budget must be sent to PSE ID 7 on this device */
+		config->pse_id_set_budget_mask = 0x80;
+	}
+
 	free(compatible);
 }
 


### PR DESCRIPTION
realtek-poe: add PSE ID quirk for Zyxel GS1900-48HP A1

The GS1900-48HP A1 uses PSE ID 7 for its PoE budget. The default pse_id_set_budget_mask (0x01) sends the budget to PSE ID 0 which is ignored by this device, resulting in no PoE power delivery.

Set pse_id_set_budget_mask=0x80 so the budget command is sent to PSE ID 7, enabling PoE on all ports.

Tested-on: Zyxel GS1900-48HP v1 (RTL8393M, ST32F100 MCU, fw v17.1)