### PR TITLE
manage: return proper ubus status on success

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1223,7 +1223,10 @@ static int ubus_poe_manage_cb(struct ubus_context *ctx, struct ubus_object *obj,
 		port = &cfg->ports[i];
 		if (!port->enable || strcmp(port_name, port->name))
 			continue;
-		return poe_cmd_port_enable(mcu, i, blobmsg_get_bool(tb[1]));
+		if (poe_cmd_port_enable(mcu, i, blobmsg_get_bool(tb[1])) < 0)
+			return UBUS_STATUS_SYSTEM_ERROR;
+
+		return UBUS_STATUS_OK;
 	}
 	return UBUS_STATUS_OK;
 }


### PR DESCRIPTION
`ubus call poe manage '{"port":"lanX","enable":true}'` reports

    Command failed: ... (Parsing message data failed)

even though the command is queued and executed correctly.

When a matching port is found, `ubus_poe_manage_cb()` returns the result of `poe_cmd_port_enable()` directly. On success this is the return value of `mcu_queue_cmd()`, i.e. the number of bytes written by `ustream_write()` - 12 for a port enable frame. ubus interprets the callback return value as a ubus status code, and 12 happens to be `UBUS_STATUS_PARSE_ERROR`.

15fdcfc ("realtek-poe: manage: fix return value on command success") only fixed the fall-through case at the end of the port loop; the port-found path still leaks the byte count as a status code.

This PR maps negative results to `UBUS_STATUS_SYSTEM_ERROR` and success to `UBUS_STATUS_OK`.

Tested on a Zyxel GS1900-24HP A1 running OpenWrt 25.12.5: enable/disable via `ubus call poe manage` now returns exit code 0 and the port state changes as expected (verified with `ubus call poe info`).