### PR TITLE
quirks: match renamed GS1900-24HP A1 compatible (fixes PoE on OpenWrt 25.12)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -164,7 +164,8 @@ static void config_apply_quirks(struct config *config)
 		return;
 	}
 
-	if (!strcmp(compatible, "zyxel,gs1900-24hp-v1")) {
+	if (!strcmp(compatible, "zyxel,gs1900-24hp-v1") ||
+	    !strcmp(compatible, "zyxel,gs1900-24hp-a1")) {
 		/* Send budget command to first 8 PSE IDs */
 		config->pse_id_set_budget_mask = 0xff;
 	}


### PR DESCRIPTION
OpenWrt renamed the Zyxel GS1900-24HP v1 board to GS1900-24HP A1: since OpenWrt 25.12 the device tree compatible is `zyxel,gs1900-24hp-a1` instead of `zyxel,gs1900-24hp-v1`. The sysupgrade image still lists the old name in SUPPORTED_DEVICES, so existing installations upgrade right into this.

`config_apply_quirks()` only matches the old compatible string, so the power budget is no longer sent to all eight PSE IDs on this board. The MCU is left with a reported power budget of 0 W and never grants power on any port: ports with a powered device attached are stuck in "Requesting power" and PoE is effectively broken on OpenWrt 25.12 - `ubus call poe debug` shows `"reported_budget": 0`.

This PR additionally matches the new compatible string.

Tested on a Zyxel GS1900-24HP A1 running OpenWrt 25.12.5: the MCU reported budget goes from 0 W to 153 W (170 W budget minus guard band) and attached devices (an IP camera among them) are powered again.